### PR TITLE
add indexed element

### DIFF
--- a/includes/dim/objects/Mesh.hpp
+++ b/includes/dim/objects/Mesh.hpp
@@ -58,11 +58,13 @@ namespace dim
 		std::vector<Vector3>	positions;			// The positions data of the mesh.
 		std::vector<Vector3>	normals;			// The normals data of the mesh.
 		std::vector<Vector2>	texcoords;			// The texture coordinates data of the mesh.
+		std::vector<GLuint>     indices;			// The indices data of the mesh.
 
 		static const Mesh		circle_64;			// A circle with 64 edges.
 		static const Mesh		empty_circle_64;	// An empty circle with 64 edges.
 		static const Mesh		cone_64;			// A cone with 64 latitudes.
 		static const Mesh		cube;				// A cube.
+		static const Mesh       cubeIndexed;		// An cube with indexed vertices.
 		static const Mesh		empty_cube;			// An empty cube.
 		static const Mesh		cylinder_64;		// A cylinder with 64 latitudes.
 		static const Mesh		null;				// An empty mesh.
@@ -136,11 +138,25 @@ namespace dim
 		unsigned int get_texcoords_size() const;
 
 		/**
+		 * @brief Give the size of the indices data.
+		 *
+		 * @return the size of the indices data
+		 */
+		unsigned int get_indices_size() const;
+
+		/**
 		 * @brief Give the number of vertices in the mesh.
 		 *
 		 * @return the number of vertices in the mesh
 		 */
 		unsigned int get_nb_vertices() const;
+
+		/**
+		 * @brief Give the number of indices in the mesh.
+		 *
+		 * @return the number of indices in the mesh
+		 */
+		unsigned int get_nb_indices() const;
 
 		/**
 		 * @brief Empty the mesh.
@@ -177,6 +193,13 @@ namespace dim
 		 * @return the a new cube mesh
 		 */
 		static Mesh Cube();
+
+		/**
+		 * @brief Construct a new cube mesh with indexed vertices.
+		 *
+		 * @return the a new cube mesh
+		 */
+		static Mesh CubeIndexed();
 
 		/**
 		 * @brief Construct a new empty cube mesh.

--- a/includes/dim/opengl/VertexBuffer.hpp
+++ b/includes/dim/opengl/VertexBuffer.hpp
@@ -18,10 +18,11 @@ namespace dim
 	 */
 	enum class DataType : uint8_t
 	{
-		Positions	= 0b001,	// The position data.
-		Normals		= 0b010,	// The normals data.
-		TexCoords	= 0b100,	// The texture coordinates data.
-		All			= 0b111		// All the data.
+		Positions	= 0b0001,	// The position data.
+		Normals		= 0b0010,	// The normals data.
+		TexCoords	= 0b0100,	// The texture coordinates data.
+		Indices		= 0b1000,	// The indices data.
+		All			= 0b1111	// All the data.
 	};
 
 	/**
@@ -46,7 +47,9 @@ namespace dim
 		Shader							shader;			// The shader used by the vertex buffer.
 		std::shared_ptr<GLuint>			vbo;			// The OpenGL vertex buffer object.
 		std::shared_ptr<GLuint>			vao;			// The OpenGL vertex array object.
+		std::shared_ptr<GLuint>			ebo;			// The OpenGL element buffer object.
 		std::shared_ptr<unsigned int>	nb_vertices;	// The number of vertices of the mesh.
+		std::shared_ptr<unsigned int>	nb_indices;		// The number of indices of the mesh.
 
 	public:
 
@@ -160,6 +163,13 @@ namespace dim
 		 * @return the number of vertices of the mesh
 		 */
 		unsigned int get_nb_vertices() const;
+
+		/**
+		 * @brief Give the number of indices of the mesh.
+		 *
+		 * @return the number of indices of the mesh
+		 */
+		unsigned int get_nb_indices() const;
 
 		/**
 		 * @brief Bind the vertex buffer.

--- a/sources/objects/Mesh.cpp
+++ b/sources/objects/Mesh.cpp
@@ -376,7 +376,6 @@ namespace dim
 			{0, 1}, {1, 1}, {1, 0}, {0, 0}
 		};
 
-		// Clockwise Indices
 		mesh.indices =
 		{
 			0, 1, 2, 2, 3, 0,

--- a/sources/objects/Mesh.cpp
+++ b/sources/objects/Mesh.cpp
@@ -6,6 +6,7 @@ namespace dim
 	const Mesh	Mesh::empty_circle_64	= Mesh::EmptyCircle(64);
 	const Mesh	Mesh::cone_64			= Mesh::Cone(64);
 	const Mesh	Mesh::cube				= Mesh::Cube();
+	const Mesh	Mesh::cubeIndexed		= Mesh::CubeIndexed();
 	const Mesh	Mesh::empty_cube		= Mesh::EmptyCube();
 	const Mesh	Mesh::cylinder_64		= Mesh::Cylinder(64);
 	const Mesh	Mesh::null				= Mesh();
@@ -20,6 +21,7 @@ namespace dim
 		positions.clear();
 		normals.clear();
 		texcoords.clear();
+		indices.clear();
 	}
 
 	Mesh& Mesh::operator+=(const Mesh& other)
@@ -32,6 +34,9 @@ namespace dim
 
 		for (auto& texcoord : other.texcoords)
 			texcoords.push_back(texcoord);
+
+		for (auto& indice : other.indices)
+			indices.push_back(indice);
 
 		return *this;
 	}
@@ -51,7 +56,7 @@ namespace dim
 
 	unsigned int Mesh::get_data_size() const
 	{
-		return static_cast<unsigned int>(positions.size() * sizeof(Vector3) + normals.size() * sizeof(Vector3) + texcoords.size() * sizeof(Vector2));
+		return static_cast<unsigned int>(positions.size() * sizeof(Vector3) + normals.size() * sizeof(Vector3) + texcoords.size() * sizeof(Vector2) + indices.size() * sizeof(float));
 	}
 
 	unsigned int Mesh::get_positions_size() const
@@ -69,9 +74,19 @@ namespace dim
 		return static_cast<unsigned int>(texcoords.size() * sizeof(Vector2));
 	}
 
+	unsigned int Mesh::get_indices_size() const
+	{
+		return static_cast<unsigned int>(indices.size() * sizeof(GLuint));
+	}
+
 	unsigned int Mesh::get_nb_vertices() const
 	{
 		return static_cast<unsigned int>(positions.size());
+	}
+
+	unsigned int Mesh::get_nb_indices() const
+	{
+		return static_cast<unsigned int>(indices.size());
 	}
 
 	void Mesh::clear()
@@ -79,6 +94,7 @@ namespace dim
 		positions.clear();
 		normals.clear();
 		texcoords.clear();
+		indices.clear();
 	}
 
 	Mesh Mesh::Circle(unsigned int nb_edges)
@@ -323,6 +339,57 @@ namespace dim
 
 		return mesh;
 	}
+
+	Mesh Mesh::CubeIndexed()
+	{
+		Mesh mesh;
+		mesh.draw_type = DrawType::Triangles;
+		float size = 1.0f;
+
+		mesh.positions =
+		{
+			{0.5f, -0.5f, -0.5f},  {-0.5f, -0.5f, -0.5f}, {-0.5f, 0.5f, -0.5f}, {0.5f, 0.5f, -0.5f},	//Back
+			{-0.5f, -0.5f, 0.5f},  {0.5f, -0.5f, 0.5f},   {0.5f, 0.5f, 0.5f},   {-0.5f, 0.5f, 0.5f},	//Front
+			{0.5f, -0.5f, 0.5f},   {0.5f, -0.5f, -0.5f},  {0.5f, 0.5f, -0.5f},  {0.5f, 0.5f, 0.5f},		//Right
+			{-0.5f, -0.5f, -0.5f}, {-0.5f, -0.5f, 0.5f},  {-0.5f, 0.5f, 0.5f},  {-0.5f, 0.5f, -0.5f},	//Left
+			{-0.5f, 0.5f, 0.5f},   {0.5f, 0.5f, 0.5f},    {0.5f, 0.5f, -0.5f},  {-0.5f, 0.5f, -0.5f},	//Top
+			{-0.5f, -0.5f, -0.5f}, {0.5f, -0.5f, -0.5f},  {0.5f, -0.5f, 0.5f},  {-0.5f, -0.5f, 0.5f}	//Bottom
+		};
+
+		mesh.normals =
+		{
+			{0, 0, -1}, {0, 0, -1}, {0, 0, -1}, {0, 0, -1},	//Back
+			{0, 0, 1},  {0, 0, 1},  {0, 0, 1},  {0, 0, 1},	//Front
+			{1, 0, 0},  {1, 0, 0},  {1, 0, 0},  {1, 0, 0},	//Right
+			{-1, 0, 0}, {-1, 0, 0}, {-1, 0, 0}, {-1, 0, 0},	//Left
+			{0, 1, 0},  {0, 1, 0},  {0, 1, 0},  {0, 1, 0},	//Top
+			{0, -1, 0}, {0, -1, 0}, {0, -1, 0}, {0, -1, 0}	//Bottom
+		};
+
+		mesh.texcoords =
+		{
+			{0, 1}, {1, 1}, {1, 0}, {0, 0},
+			{0, 1}, {1, 1}, {1, 0}, {0, 0},
+			{0, 1}, {1, 1}, {1, 0}, {0, 0},
+			{0, 1}, {1, 1}, {1, 0}, {0, 0},
+			{0, 1}, {1, 1}, {1, 0}, {0, 0},
+			{0, 1}, {1, 1}, {1, 0}, {0, 0}
+		};
+
+		// Clockwise Indices
+		mesh.indices =
+		{
+			0, 1, 2, 2, 3, 0,
+			4, 5, 6, 6, 7, 4,
+			8, 9, 10, 10, 11, 8,
+			12, 13, 14, 14, 15, 12,
+			16, 17, 18, 18, 19, 16,
+			20, 21, 22, 22, 23, 20
+		};
+
+		return mesh;
+	}
+
 
 	Mesh Mesh::EmptyCube()
 	{
@@ -665,6 +732,9 @@ namespace dim
 		for (auto& texcoord : mesh_1.texcoords)
 			mesh.texcoords.push_back(texcoord);
 
+		for (auto& indice : mesh_1.indices)
+			mesh.indices.push_back(indice);
+
 		for (auto& position : mesh_2.positions)
 			mesh.positions.push_back(position);
 
@@ -673,6 +743,9 @@ namespace dim
 
 		for (auto& texcoord : mesh_2.texcoords)
 			mesh.texcoords.push_back(texcoord);
+
+		for (auto& indice : mesh_2.indices)
+			mesh.indices.push_back(indice + mesh_1.get_indices_size());
 
 		return mesh;
 	}

--- a/sources/objects/Mesh.cpp
+++ b/sources/objects/Mesh.cpp
@@ -744,7 +744,7 @@ namespace dim
 			mesh.texcoords.push_back(texcoord);
 
 		for (auto& indice : mesh_2.indices)
-			mesh.indices.push_back(indice + mesh_1.get_indices_size());
+			mesh.indices.push_back(indice + mesh_1.get_nb_indices());
 
 		return mesh;
 	}

--- a/sources/objects/Object.cpp
+++ b/sources/objects/Object.cpp
@@ -28,6 +28,7 @@ namespace dim
 	{
 		shader = other.shader;
 		mesh = other.mesh;
+		material = other.material;
 		vertex_buffer.set_shader(shader);
 		vertex_buffer.send_data(mesh);
 		texture = other.texture;
@@ -38,6 +39,7 @@ namespace dim
 		model = other.model;
 		thickness = other.thickness;
 		textured = other.textured;
+		binded = other.binded;
 
 		return *this;
 	}

--- a/sources/objects/Object.cpp
+++ b/sources/objects/Object.cpp
@@ -39,7 +39,7 @@ namespace dim
 		model = other.model;
 		thickness = other.thickness;
 		textured = other.textured;
-		binded = other.binded;
+		binded = false;
 
 		return *this;
 	}

--- a/sources/opengl/VertexBuffer.cpp
+++ b/sources/opengl/VertexBuffer.cpp
@@ -148,7 +148,6 @@ namespace dim
 						glEnableVertexAttribArray(texcoords);
 					}
 				}
-				//glBindBuffer(GL_ARRAY_BUFFER, 0);
 
 				if (send_indices)
 				{
@@ -184,12 +183,10 @@ namespace dim
 	void VertexBuffer::bind() const
 	{
 		glBindVertexArray(*vao);
-		//glBindBuffer(GL_ARRAY_BUFFER, *vbo);
 	}
 
 	void VertexBuffer::unbind()
 	{
-		//glBindBuffer(GL_ARRAY_BUFFER, 0);
 		glBindVertexArray(0);
 	}
 

--- a/sources/opengl/VertexBuffer.cpp
+++ b/sources/opengl/VertexBuffer.cpp
@@ -7,7 +7,9 @@ namespace dim
 		shader = Shader::default_shader;
 		vbo = std::make_shared<GLuint>();
 		vao = std::make_shared<GLuint>();
+		ebo = std::make_shared<GLuint>();
 		nb_vertices = std::make_shared<unsigned int>(0);
+		nb_indices = std::make_shared<unsigned int>(0);
 	}
 
 	VertexBuffer::VertexBuffer(const std::string& shader_name)
@@ -15,7 +17,9 @@ namespace dim
 		set_shader(shader_name);
 		vbo = std::make_shared<GLuint>();
 		vao = std::make_shared<GLuint>();
+		ebo = std::make_shared<GLuint>();
 		nb_vertices = std::make_shared<unsigned int>(0);
+		nb_indices = std::make_shared<unsigned int>(0);
 	}
 
 	VertexBuffer::VertexBuffer(const Shader& shader)
@@ -23,7 +27,9 @@ namespace dim
 		set_shader(shader);
 		vbo = std::make_shared<GLuint>();
 		vao = std::make_shared<GLuint>();
+		ebo = std::make_shared<GLuint>();
 		nb_vertices = std::make_shared<unsigned int>(0);
+		nb_indices = std::make_shared<unsigned int>(0);
 	}
 
 	VertexBuffer::VertexBuffer(const std::string& shader_name, const Mesh& mesh, DataType data_sent)
@@ -31,7 +37,9 @@ namespace dim
 		set_shader(shader_name);
 		vbo = std::make_shared<GLuint>();
 		vao = std::make_shared<GLuint>();
+		ebo = std::make_shared<GLuint>();
 		nb_vertices = std::make_shared<unsigned int>(0);
+		nb_indices = std::make_shared<unsigned int>(0);
 		send_data(mesh, data_sent);
 	}
 
@@ -40,7 +48,9 @@ namespace dim
 		set_shader(shader);
 		vbo = std::make_shared<GLuint>();
 		vao = std::make_shared<GLuint>();
+		ebo = std::make_shared<GLuint>();
 		nb_vertices = std::make_shared<unsigned int>(0);
+		nb_indices = std::make_shared<unsigned int>(0);
 		send_data(mesh, data_sent);
 	}
 
@@ -49,6 +59,7 @@ namespace dim
 		if (vbo.unique())
 		{
 			glDeleteBuffers(1, &(*vbo));
+			glDeleteBuffers(1, &(*ebo));
 			glDeleteVertexArrays(1, &(*vao));
 		}
 	}
@@ -80,11 +91,13 @@ namespace dim
 		#pragma warning(push, 0)
 
 		glDeleteBuffers(1, &(*vbo));
+		glDeleteBuffers(1, &(*ebo));
 		glDeleteVertexArrays(1, &(*vao));
 
 		bool send_positions = (data_sent & DataType::Positions) == DataType::Positions;
 		bool send_normals = (data_sent & DataType::Normals) == DataType::Normals;
 		bool send_texcoords = (data_sent & DataType::TexCoords) == DataType::TexCoords;
+		bool send_indices = (data_sent & DataType::Indices) == DataType::Indices;
 
 		*nb_vertices = (data_sent == static_cast<DataType>(0) ? 0 : mesh.get_nb_vertices());
 
@@ -135,7 +148,17 @@ namespace dim
 						glEnableVertexAttribArray(texcoords);
 					}
 				}
-				glBindBuffer(GL_ARRAY_BUFFER, 0);
+				//glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+				if (send_indices)
+				{
+					*nb_indices = mesh.get_nb_indices();
+
+					glGenBuffers(1, &(*ebo));
+					glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, *ebo);
+					glBufferData(GL_ELEMENT_ARRAY_BUFFER, mesh.indices.size() * sizeof(GLuint), mesh.indices.data(), GL_STATIC_DRAW);
+				}
+
 			}
 			glBindVertexArray(0);
 		}
@@ -153,22 +176,32 @@ namespace dim
 		return *nb_vertices;
 	}
 
+	unsigned int VertexBuffer::get_nb_indices() const
+	{
+		return *nb_indices;
+	}
+
 	void VertexBuffer::bind() const
 	{
 		glBindVertexArray(*vao);
-		glBindBuffer(GL_ARRAY_BUFFER, *vbo);
+		//glBindBuffer(GL_ARRAY_BUFFER, *vbo);
 	}
 
 	void VertexBuffer::unbind()
 	{
-		glBindBuffer(GL_ARRAY_BUFFER, 0);
+		//glBindBuffer(GL_ARRAY_BUFFER, 0);
 		glBindVertexArray(0);
 	}
 
 	void VertexBuffer::draw(DrawType draw_type) const
 	{
 		if (*nb_vertices)
-			glDrawArrays(static_cast<GLenum>(draw_type == DrawType::Default ? DrawType::Triangles : draw_type), 0, *nb_vertices);
+		{
+			if (*nb_indices)
+				glDrawElements(static_cast<GLenum>(draw_type == DrawType::Default ? DrawType::Triangles : draw_type), *nb_indices, GL_UNSIGNED_INT, nullptr);
+			else
+				glDrawArrays(static_cast<GLenum>(draw_type == DrawType::Default ? DrawType::Triangles : draw_type), 0, *nb_vertices);
+		}
 	}
 
 	DataType operator&(DataType type_1, DataType type_2)


### PR DESCRIPTION
Allow to draw indexed vertexbuffer.

The element buffer "ebo" is included in the DImension3D VertexBuffer object. It is binded automatically via the ArrayBuffer (as well as the vbo).

An exemple to test the code is available with the mesh "CubeIndexed". It's drawable.

Test code using the squeleton project :

```cpp
// Create objects
dim::Object object_1(dim::Mesh::Sphere(256, 256), dim::Material(dim::Color(1.f, 0.1f, 0.1f), 0.1f, 0.5f, 0.6f, 30.f));

dim::Object object_2(dim::Mesh::Cone(256), dim::Material(dim::Color(0.1f, 1.f, 0.1f), 0.1f, 0.5f, 0.6f, 30.f));
object_2.move(dim::Vector3(1.1f, 0.f, 0.f));

dim::Object object_3(dim::Mesh::Cylinder(256), dim::Material(dim::Color(0.1f, 0.1f, 1.f), 0.1f, 0.5f, 0.6f, 30.f));
object_3.move(dim::Vector3(-1.1f, 0.f, 0.f));

dim::Object object_4(dim::Mesh::CubeIndexed(), dim::Material(dim::Color(1.f, 0.1f, 1.f), 0.1f, 0.5f, 0.6f, 30.f));
object_4.move(dim::Vector3(-2.2f, 0.f, 0.f));

// ...

// Draw the objects
scene.draw(object_1);
scene.draw(object_2);
scene.draw(object_3);
scene.draw(object_4);
```

Result :
![image](https://user-images.githubusercontent.com/19150723/168419776-95a6a925-5ba6-46ae-acb5-2940259d6d10.png)

Another example displaying a terrain :
![Heighmap](https://user-images.githubusercontent.com/19150723/168419810-39b56f32-929f-47ef-b16b-4f08ff534d68.PNG)

