### PR TITLE
Fixed shader compilation issue on vega 7

### DIFF
--- a/sources/opengl/Shader.cpp
+++ b/sources/opengl/Shader.cpp
@@ -80,7 +80,7 @@ namespace dim
 			"\n"
 			"void main()\n"
 			"{\n"
-			"	vec4 initial_color = (1 - u_textured) * u_material.color + u_textured * texture2D(u_texture, v_texcoord);\n"
+			"	vec4 initial_color = (1 - u_textured) * u_material.color + u_textured * texture(u_texture, v_texcoord);\n"
 			"\n"
 			"	if (u_material.illuminated == 1)\n"
 			"	{\n"


### PR DESCRIPTION
texture2D() is deprecated since OGL ES 3.0, it's been replaced by texture(). This has caused the program not to work on vega 7 iGPUs.