### PR TITLE
texture2D is deprecated

### DIFF
--- a/sources/opengl/Shader.cpp
+++ b/sources/opengl/Shader.cpp
@@ -80,7 +80,7 @@ namespace dim
 			"\n"
 			"void main()\n"
 			"{\n"
-			"	vec4 initial_color = (1 - u_textured) * u_material.color + u_textured * texture2D(u_texture, v_texcoord);\n"
+			"	vec4 initial_color = (1 - u_textured) * u_material.color + u_textured * texture(u_texture, v_texcoord);\n"
 			"\n"
 			"	if (u_material.illuminated == 1)\n"
 			"	{\n"


### PR DESCRIPTION
texture2D is being replaced by texture. Which cause some issues, especially in some @angeluriot 's repos
Sources are given on this [thread](https://stackoverflow.com/questions/12307278/texture-vs-texture2d-in-glsl)